### PR TITLE
Update README with standard badges and project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Master Calibration Frame Automation
+# ap-master-calibration
+
+[![Test](https://github.com/jewzaam/ap-create-master/actions/workflows/test.yml/badge.svg)](https://github.com/jewzaam/ap-create-master/actions/workflows/test.yml)
+[![Coverage](https://github.com/jewzaam/ap-create-master/actions/workflows/coverage.yml/badge.svg)](https://github.com/jewzaam/ap-create-master/actions/workflows/coverage.yml)
+[![Lint](https://github.com/jewzaam/ap-create-master/actions/workflows/lint.yml/badge.svg)](https://github.com/jewzaam/ap-create-master/actions/workflows/lint.yml)
+[![Format](https://github.com/jewzaam/ap-create-master/actions/workflows/format.yml/badge.svg)](https://github.com/jewzaam/ap-create-master/actions/workflows/format.yml)
+[![Typecheck](https://github.com/jewzaam/ap-create-master/actions/workflows/typecheck.yml/badge.svg)](https://github.com/jewzaam/ap-create-master/actions/workflows/typecheck.yml)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 Automated generation of master bias, dark, and flat calibration frames for PixInsight.
 


### PR DESCRIPTION
- Change title from prose description to package name (ap-master-calibration)
- Add GitHub workflow badges for Test, Coverage, Lint, Format, and Typecheck
- Add Python 3.10+ version badge
- Add Black code style badge

Assisted-by: Claude Code (Claude Sonnet 4.5)