### PR TITLE
Remove constant remapping anti-pattern

### DIFF
--- a/ap_create_master/config.py
+++ b/ap_create_master/config.py
@@ -7,48 +7,55 @@ Defines required FITS keywords for grouping each frame type.
 Uses normalized keyword names from ap-common normalization.
 """
 
-# Normalized keyword names (as returned by ap-common)
-# These match the normalized output from ap_common.normalize_headers()
-KEYWORD_TYPE = "type"  # From IMAGETYP
-KEYWORD_CAMERA = "camera"  # From INSTRUME
-KEYWORD_SETTEMP = "settemp"  # From SET-TEMP or SETTEMP
-KEYWORD_GAIN = "gain"  # From GAIN (lowercase)
-KEYWORD_OFFSET = "offset"  # From OFFSET (lowercase)
-KEYWORD_READOUTMODE = "readoutmode"  # From READOUTM
-KEYWORD_EXPOSURESECONDS = "exposureseconds"  # From EXPOSURE/EXPTIME/EXP
-KEYWORD_DATE = "date"  # From DATE-OBS
-KEYWORD_FILTER = "filter"  # From FILTER
+# Import constants from ap-common
+from ap_common.constants import (
+    NORMALIZED_HEADER_TYPE,
+    NORMALIZED_HEADER_CAMERA,
+    NORMALIZED_HEADER_SETTEMP,
+    NORMALIZED_HEADER_GAIN,
+    NORMALIZED_HEADER_OFFSET,
+    NORMALIZED_HEADER_READOUTMODE,
+    NORMALIZED_HEADER_EXPOSURESECONDS,
+    NORMALIZED_HEADER_DATE,
+    NORMALIZED_HEADER_FILTER,
+    TYPE_BIAS,
+    TYPE_DARK,
+    TYPE_FLAT,
+)
+
+# Frame type list for processing
+FRAME_TYPES = [TYPE_BIAS.lower(), TYPE_DARK.lower(), TYPE_FLAT.lower()]
 
 # Required FITS keywords for grouping each frame type
 # Keys are frame types (as found in TYPE keyword)
 # Values are lists of normalized keyword names required for grouping
 REQUIRED_KEYWORDS = {
-    "bias": [
-        KEYWORD_TYPE,
-        KEYWORD_SETTEMP,
-        KEYWORD_GAIN,
-        KEYWORD_OFFSET,
-        KEYWORD_CAMERA,
-        KEYWORD_READOUTMODE,
+    TYPE_BIAS.lower(): [
+        NORMALIZED_HEADER_TYPE,
+        NORMALIZED_HEADER_SETTEMP,
+        NORMALIZED_HEADER_GAIN,
+        NORMALIZED_HEADER_OFFSET,
+        NORMALIZED_HEADER_CAMERA,
+        NORMALIZED_HEADER_READOUTMODE,
     ],
-    "dark": [
-        KEYWORD_TYPE,
-        KEYWORD_EXPOSURESECONDS,
-        KEYWORD_SETTEMP,
-        KEYWORD_GAIN,
-        KEYWORD_OFFSET,
-        KEYWORD_CAMERA,
-        KEYWORD_READOUTMODE,
+    TYPE_DARK.lower(): [
+        NORMALIZED_HEADER_TYPE,
+        NORMALIZED_HEADER_EXPOSURESECONDS,
+        NORMALIZED_HEADER_SETTEMP,
+        NORMALIZED_HEADER_GAIN,
+        NORMALIZED_HEADER_OFFSET,
+        NORMALIZED_HEADER_CAMERA,
+        NORMALIZED_HEADER_READOUTMODE,
     ],
-    "flat": [
-        KEYWORD_TYPE,
-        KEYWORD_FILTER,
-        KEYWORD_DATE,
-        KEYWORD_SETTEMP,
-        KEYWORD_GAIN,
-        KEYWORD_OFFSET,
-        KEYWORD_CAMERA,
-        KEYWORD_READOUTMODE,
+    TYPE_FLAT.lower(): [
+        NORMALIZED_HEADER_TYPE,
+        NORMALIZED_HEADER_FILTER,
+        NORMALIZED_HEADER_DATE,
+        NORMALIZED_HEADER_SETTEMP,
+        NORMALIZED_HEADER_GAIN,
+        NORMALIZED_HEADER_OFFSET,
+        NORMALIZED_HEADER_CAMERA,
+        NORMALIZED_HEADER_READOUTMODE,
     ],
 }
 
@@ -56,11 +63,11 @@ REQUIRED_KEYWORDS = {
 # These are the instrument settings that must match
 # (excludes DATE and FILTER, which are flat-specific)
 MASTER_MATCH_KEYWORDS = [
-    KEYWORD_CAMERA,
-    KEYWORD_SETTEMP,
-    KEYWORD_GAIN,
-    KEYWORD_OFFSET,
-    KEYWORD_READOUTMODE,
+    NORMALIZED_HEADER_CAMERA,
+    NORMALIZED_HEADER_SETTEMP,
+    NORMALIZED_HEADER_GAIN,
+    NORMALIZED_HEADER_OFFSET,
+    NORMALIZED_HEADER_READOUTMODE,
 ]
 
 # Frame types to ignore (e.g., lights)

--- a/ap_create_master/master_matching.py
+++ b/ap_create_master/master_matching.py
@@ -48,7 +48,7 @@ def find_matching_master_for_flat(
     # Build filters dict: TYPE and all instrument settings
     # TYPE in master files is "MASTER BIAS" or "MASTER DARK" (uppercase, two words)
     filters = {
-        config.KEYWORD_TYPE: f"MASTER {master_type.upper()}",
+        config.NORMALIZED_HEADER_TYPE: f"MASTER {master_type.upper()}",
     }
 
     # Add instrument setting filters from flat headers
@@ -58,9 +58,11 @@ def find_matching_master_for_flat(
             filters[keyword] = str(value).strip()
 
     # Build required_properties list (TYPE + instrument settings + EXPOSURESECONDS for darks)
-    required_properties = [config.KEYWORD_TYPE] + list(config.MASTER_MATCH_KEYWORDS)
+    required_properties = [config.NORMALIZED_HEADER_TYPE] + list(
+        config.MASTER_MATCH_KEYWORDS
+    )
     if master_type == "dark":
-        required_properties.append(config.KEYWORD_EXPOSURESECONDS)
+        required_properties.append(config.NORMALIZED_HEADER_EXPOSURESECONDS)
 
     # Get filtered metadata using ap-common
     try:
@@ -119,7 +121,9 @@ def _find_best_dark_match(
         target_exposure = min(flat_exposure_times)
     else:
         # Use exposure from headers
-        target_exposure_raw: Any = flat_headers.get(config.KEYWORD_EXPOSURESECONDS)
+        target_exposure_raw: Any = flat_headers.get(
+            config.NORMALIZED_HEADER_EXPOSURESECONDS
+        )
         if target_exposure_raw is None:
             # No exposure time available, return first match
             return next(iter(matching_masters.keys()))
@@ -132,7 +136,7 @@ def _find_best_dark_match(
     # Extract exposure times from masters
     dark_candidates: list[DarkCandidate] = []
     for filename, metadata in matching_masters.items():
-        exposure = metadata.get(config.KEYWORD_EXPOSURESECONDS)
+        exposure = metadata.get(config.NORMALIZED_HEADER_EXPOSURESECONDS)
         if exposure is None:
             continue
         try:

--- a/ap_create_master/script_generator.py
+++ b/ap_create_master/script_generator.py
@@ -57,7 +57,7 @@ def generate_master_filename(metadata: Dict[str, str], frame_type: str) -> str:
     # Add parts from required keywords (excluding TYPE)
     required = config.REQUIRED_KEYWORDS[frame_type]
     for keyword in required:
-        if keyword == config.KEYWORD_TYPE:
+        if keyword == config.NORMALIZED_HEADER_TYPE:
             continue  # Skip TYPE keyword
 
         value = metadata.get(keyword, "UNKNOWN")

--- a/tests/test_calibrate_masters.py
+++ b/tests/test_calibrate_masters.py
@@ -39,20 +39,20 @@ class TestGenerateMasters:
         # Mock file discovery
         mock_get_filtered.return_value = {
             "bias1.fits": {
-                config.KEYWORD_TYPE: "bias",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_TYPE: "bias",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
             },
             "bias2.fits": {
-                config.KEYWORD_TYPE: "bias",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_TYPE: "bias",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
             },
         }
 
@@ -72,11 +72,11 @@ class TestGenerateMasters:
 
         # Mock metadata extraction
         mock_get_metadata.return_value = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         # Mock script generation
@@ -139,15 +139,15 @@ class TestGenerateMasters:
         # Mock flat file discovery
         mock_get_filtered.return_value = {
             "flat1.fits": {
-                config.KEYWORD_TYPE: "flat",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_DATE: "2026-01-15",
-                config.KEYWORD_FILTER: "B",
-                config.KEYWORD_EXPOSURESECONDS: "1.5",
+                config.NORMALIZED_HEADER_TYPE: "flat",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                config.NORMALIZED_HEADER_FILTER: "B",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
             }
         }
 
@@ -172,13 +172,13 @@ class TestGenerateMasters:
 
         # Mock metadata extraction
         mock_get_metadata.return_value = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_DATE: "2026-01-15",
-            config.KEYWORD_FILTER: "B",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
         }
 
         # Mock master finding
@@ -218,12 +218,12 @@ class TestGenerateMasters:
 
         mock_get_filtered.return_value = {
             "bias1.fits": {
-                config.KEYWORD_TYPE: "bias",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_TYPE: "bias",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
             }
         }
 
@@ -237,11 +237,11 @@ class TestGenerateMasters:
         }
 
         mock_get_metadata.return_value = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         mock_generate_script.return_value = "// Generated script"
@@ -268,7 +268,9 @@ class TestGenerateMasters:
 
         # Simulate ap-common failure for one frame type
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "").lower()
+            frame_type = (
+                kwargs.get("filters", {}).get(config.NORMALIZED_HEADER_TYPE, "").lower()
+            )
             if frame_type == "dark":
                 raise PermissionError("Access denied to directory")
             return {}
@@ -307,26 +309,26 @@ class TestGenerateMasters:
         # Flat with invalid exposure time (non-numeric string)
         mock_get_filtered.return_value = {
             "flat1.fits": {
-                config.KEYWORD_TYPE: "flat",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_DATE: "2026-01-15",
-                config.KEYWORD_FILTER: "B",
-                config.KEYWORD_EXPOSURESECONDS: "invalid",  # Non-numeric
+                config.NORMALIZED_HEADER_TYPE: "flat",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                config.NORMALIZED_HEADER_FILTER: "B",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "invalid",  # Non-numeric
             },
             "flat2.fits": {
-                config.KEYWORD_TYPE: "flat",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_DATE: "2026-01-15",
-                config.KEYWORD_FILTER: "B",
-                config.KEYWORD_EXPOSURESECONDS: "1.5",  # Valid
+                config.NORMALIZED_HEADER_TYPE: "flat",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                config.NORMALIZED_HEADER_FILTER: "B",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",  # Valid
             },
         }
 
@@ -353,13 +355,13 @@ class TestGenerateMasters:
         }
 
         mock_get_metadata.return_value = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_DATE: "2026-01-15",
-            config.KEYWORD_FILTER: "B",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
         }
 
         mock_find_master.return_value = "dark_master.xisf"

--- a/tests/test_calibrate_masters_integration.py
+++ b/tests/test_calibrate_masters_integration.py
@@ -37,17 +37,19 @@ class TestRealWorldWorkflows:
 
         # Mock dark file discovery only
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "DARK":
                 return {
                     "dark1.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "60.0",
-                        config.KEYWORD_CAMERA: "ATR585M",
-                        config.KEYWORD_SETTEMP: "-10.00",
-                        config.KEYWORD_GAIN: "239",
-                        config.KEYWORD_OFFSET: "150",
-                        config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                        config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                        config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                        config.NORMALIZED_HEADER_GAIN: "239",
+                        config.NORMALIZED_HEADER_OFFSET: "150",
+                        config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                     }
                 }
             return {}
@@ -67,12 +69,12 @@ class TestRealWorldWorkflows:
         }
 
         mock_get_metadata.return_value = {
-            config.KEYWORD_EXPOSURESECONDS: "60.0",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         mock_generate_script.return_value = "// Generated script"
@@ -105,14 +107,16 @@ class TestRealWorldWorkflows:
 
         # Mock both bias and dark discovery
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "BIAS":
-                return {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+                return {"bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}}
             elif frame_type == "DARK":
                 return {
                     "dark1.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "60.0",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
                     }
                 }
             return {}
@@ -129,10 +133,10 @@ class TestRealWorldWorkflows:
         mock_group_files.side_effect = group_side_effect
 
         mock_get_metadata.side_effect = [
-            {config.KEYWORD_CAMERA: "ATR585M"},  # bias metadata
+            {config.NORMALIZED_HEADER_CAMERA: "ATR585M"},  # bias metadata
             {
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
             },  # dark metadata
         ]
 
@@ -170,23 +174,25 @@ class TestRealWorldWorkflows:
 
         # Mock all three frame types
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "BIAS":
-                return {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+                return {"bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}}
             elif frame_type == "DARK":
                 return {
                     "dark1.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "60.0",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
                     }
                 }
             elif frame_type == "FLAT":
                 return {
                     "flat1.fits": {
-                        config.KEYWORD_TYPE: "flat",
-                        config.KEYWORD_FILTER: "B",
-                        config.KEYWORD_DATE: "2026-01-15",
-                        config.KEYWORD_EXPOSURESECONDS: "1.5",
+                        config.NORMALIZED_HEADER_TYPE: "flat",
+                        config.NORMALIZED_HEADER_FILTER: "B",
+                        config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
                     }
                 }
             return {}
@@ -203,7 +209,9 @@ class TestRealWorldWorkflows:
                     ("flat", "B", "2026-01-15"): [
                         {
                             "path": "flat1.fits",
-                            "headers": {config.KEYWORD_EXPOSURESECONDS: "1.5"},
+                            "headers": {
+                                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5"
+                            },
                         }
                     ]
                 }
@@ -212,11 +220,11 @@ class TestRealWorldWorkflows:
         mock_group_files.side_effect = group_side_effect
 
         mock_get_metadata.side_effect = [
-            {config.KEYWORD_CAMERA: "ATR585M"},  # bias metadata
-            {config.KEYWORD_EXPOSURESECONDS: "60.0"},  # dark metadata
+            {config.NORMALIZED_HEADER_CAMERA: "ATR585M"},  # bias metadata
+            {config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0"},  # dark metadata
             {
-                config.KEYWORD_FILTER: "B",
-                config.KEYWORD_DATE: "2026-01-15",
+                config.NORMALIZED_HEADER_FILTER: "B",
+                config.NORMALIZED_HEADER_DATE: "2026-01-15",
             },  # flat metadata
         ]
 
@@ -253,20 +261,22 @@ class TestRealWorldWorkflows:
 
         # Mock darks with different exposures
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "DARK":
                 return {
                     "dark_60s.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "60.0",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
                     },
                     "dark_120s.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "120.0",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "120.0",
                     },
                     "dark_300s.fits": {
-                        config.KEYWORD_TYPE: "dark",
-                        config.KEYWORD_EXPOSURESECONDS: "300.0",
+                        config.NORMALIZED_HEADER_TYPE: "dark",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "300.0",
                     },
                 }
             return {}
@@ -280,9 +290,9 @@ class TestRealWorldWorkflows:
         }
 
         mock_get_metadata.side_effect = [
-            {config.KEYWORD_EXPOSURESECONDS: "60.0"},
-            {config.KEYWORD_EXPOSURESECONDS: "120.0"},
-            {config.KEYWORD_EXPOSURESECONDS: "300.0"},
+            {config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0"},
+            {config.NORMALIZED_HEADER_EXPOSURESECONDS: "120.0"},
+            {config.NORMALIZED_HEADER_EXPOSURESECONDS: "300.0"},
         ]
 
         mock_generate_script.return_value = "// Generated script"
@@ -312,16 +322,18 @@ class TestRealWorldWorkflows:
         os.makedirs(input_dir, exist_ok=True)
 
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "BIAS":
-                return {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+                return {"bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}}
             return {}
 
         mock_get_filtered.side_effect = side_effect
         mock_group_files.return_value = {
             ("bias",): [{"path": "bias1.fits", "headers": {}}]
         }
-        mock_get_metadata.return_value = {config.KEYWORD_CAMERA: "ATR585M"}
+        mock_get_metadata.return_value = {config.NORMALIZED_HEADER_CAMERA: "ATR585M"}
         mock_generate_script.return_value = "// Generated script"
 
         scripts = generate_masters(input_dir, output_dir)
@@ -354,14 +366,16 @@ class TestRealWorldWorkflows:
         os.makedirs(input_dir, exist_ok=True)
 
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "FLAT":
                 return {
                     "flat1.fits": {
-                        config.KEYWORD_TYPE: "flat",
-                        config.KEYWORD_FILTER: "B",
-                        config.KEYWORD_DATE: "2026-01-15",
-                        config.KEYWORD_EXPOSURESECONDS: "1.5",
+                        config.NORMALIZED_HEADER_TYPE: "flat",
+                        config.NORMALIZED_HEADER_FILTER: "B",
+                        config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
                     }
                 }
             return {}
@@ -371,13 +385,13 @@ class TestRealWorldWorkflows:
             ("flat", "B", "2026-01-15"): [
                 {
                     "path": "flat1.fits",
-                    "headers": {config.KEYWORD_EXPOSURESECONDS: "1.5"},
+                    "headers": {config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5"},
                 }
             ]
         }
         mock_get_metadata.return_value = {
-            config.KEYWORD_FILTER: "B",
-            config.KEYWORD_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
         }
         mock_find_master.side_effect = ["bias_master.xisf", "dark_master.xisf"]
         mock_generate_script.return_value = "// Generated script"
@@ -414,14 +428,16 @@ class TestRealWorldWorkflows:
         os.makedirs(input_dir, exist_ok=True)
 
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "FLAT":
                 return {
                     "flat1.fits": {
-                        config.KEYWORD_TYPE: "flat",
-                        config.KEYWORD_FILTER: "B",
-                        config.KEYWORD_DATE: "2026-01-15",
-                        config.KEYWORD_EXPOSURESECONDS: "1.5",
+                        config.NORMALIZED_HEADER_TYPE: "flat",
+                        config.NORMALIZED_HEADER_FILTER: "B",
+                        config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
                     }
                 }
             return {}
@@ -431,13 +447,13 @@ class TestRealWorldWorkflows:
             ("flat", "B", "2026-01-15"): [
                 {
                     "path": "flat1.fits",
-                    "headers": {config.KEYWORD_EXPOSURESECONDS: "1.5"},
+                    "headers": {config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5"},
                 }
             ]
         }
         mock_get_metadata.return_value = {
-            config.KEYWORD_FILTER: "B",
-            config.KEYWORD_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
         }
         mock_generate_script.return_value = "// Generated script"
 
@@ -473,16 +489,18 @@ class TestRealWorldWorkflows:
         os.makedirs(input_dir, exist_ok=True)
 
         def side_effect(*args, **kwargs):
-            frame_type = kwargs.get("filters", {}).get(config.KEYWORD_TYPE, "")
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
             if frame_type == "BIAS":
-                return {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+                return {"bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}}
             elif frame_type == "FLAT":
                 return {
                     "flat1.fits": {
-                        config.KEYWORD_TYPE: "flat",
-                        config.KEYWORD_FILTER: "B",
-                        config.KEYWORD_DATE: "2026-01-15",
-                        config.KEYWORD_EXPOSURESECONDS: "1.5",
+                        config.NORMALIZED_HEADER_TYPE: "flat",
+                        config.NORMALIZED_HEADER_FILTER: "B",
+                        config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                        config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
                     }
                 }
             return {}
@@ -497,7 +515,9 @@ class TestRealWorldWorkflows:
                     ("flat", "B", "2026-01-15"): [
                         {
                             "path": "flat1.fits",
-                            "headers": {config.KEYWORD_EXPOSURESECONDS: "1.5"},
+                            "headers": {
+                                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5"
+                            },
                         }
                     ]
                 }
@@ -506,10 +526,10 @@ class TestRealWorldWorkflows:
         mock_group_files.side_effect = group_side_effect
 
         mock_get_metadata.side_effect = [
-            {config.KEYWORD_CAMERA: "ATR585M"},  # bias metadata
+            {config.NORMALIZED_HEADER_CAMERA: "ATR585M"},  # bias metadata
             {
-                config.KEYWORD_FILTER: "B",
-                config.KEYWORD_DATE: "2026-01-15",
+                config.NORMALIZED_HEADER_FILTER: "B",
+                config.NORMALIZED_HEADER_DATE: "2026-01-15",
             },  # flat metadata
         ]
 
@@ -547,11 +567,13 @@ class TestOutputStructure:
         output_dir = str(tmp_path / "output")
         os.makedirs(input_dir, exist_ok=True)
 
-        mock_get_filtered.return_value = {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+        mock_get_filtered.return_value = {
+            "bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}
+        }
         mock_group_files.return_value = {
             ("bias",): [{"path": "bias1.fits", "headers": {}}]
         }
-        mock_get_metadata.return_value = {config.KEYWORD_CAMERA: "ATR585M"}
+        mock_get_metadata.return_value = {config.NORMALIZED_HEADER_CAMERA: "ATR585M"}
         mock_generate_script.return_value = "// Generated script"
 
         scripts = generate_masters(input_dir, output_dir)
@@ -583,11 +605,13 @@ class TestOutputStructure:
         output_dir = str(tmp_path / "output")
         os.makedirs(input_dir, exist_ok=True)
 
-        mock_get_filtered.return_value = {"bias1.fits": {config.KEYWORD_TYPE: "bias"}}
+        mock_get_filtered.return_value = {
+            "bias1.fits": {config.NORMALIZED_HEADER_TYPE: "bias"}
+        }
         mock_group_files.return_value = {
             ("bias",): [{"path": "bias1.fits", "headers": {}}]
         }
-        mock_get_metadata.return_value = {config.KEYWORD_CAMERA: "ATR585M"}
+        mock_get_metadata.return_value = {config.NORMALIZED_HEADER_CAMERA: "ATR585M"}
         mock_generate_script.return_value = "// Generated script"
 
         scripts = generate_masters(input_dir, output_dir, timestamp="20260127_120000")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,15 +12,15 @@ class TestConfig:
 
     def test_keyword_constants_defined(self):
         """Test that all keyword constants are defined."""
-        assert config.KEYWORD_TYPE == "type"
-        assert config.KEYWORD_CAMERA == "camera"
-        assert config.KEYWORD_SETTEMP == "settemp"
-        assert config.KEYWORD_GAIN == "gain"
-        assert config.KEYWORD_OFFSET == "offset"
-        assert config.KEYWORD_READOUTMODE == "readoutmode"
-        assert config.KEYWORD_EXPOSURESECONDS == "exposureseconds"
-        assert config.KEYWORD_DATE == "date"
-        assert config.KEYWORD_FILTER == "filter"
+        assert config.NORMALIZED_HEADER_TYPE == "type"
+        assert config.NORMALIZED_HEADER_CAMERA == "camera"
+        assert config.NORMALIZED_HEADER_SETTEMP == "settemp"
+        assert config.NORMALIZED_HEADER_GAIN == "gain"
+        assert config.NORMALIZED_HEADER_OFFSET == "offset"
+        assert config.NORMALIZED_HEADER_READOUTMODE == "readoutmode"
+        assert config.NORMALIZED_HEADER_EXPOSURESECONDS == "exposureseconds"
+        assert config.NORMALIZED_HEADER_DATE == "date"
+        assert config.NORMALIZED_HEADER_FILTER == "filter"
 
     def test_required_keywords_structure(self):
         """Test that REQUIRED_KEYWORDS has correct structure."""
@@ -29,18 +29,23 @@ class TestConfig:
         assert "flat" in config.REQUIRED_KEYWORDS
 
         # Bias should not include exposureseconds
-        assert config.KEYWORD_EXPOSURESECONDS not in config.REQUIRED_KEYWORDS["bias"]
+        assert (
+            config.NORMALIZED_HEADER_EXPOSURESECONDS
+            not in config.REQUIRED_KEYWORDS["bias"]
+        )
         # Dark should include exposureseconds
-        assert config.KEYWORD_EXPOSURESECONDS in config.REQUIRED_KEYWORDS["dark"]
+        assert (
+            config.NORMALIZED_HEADER_EXPOSURESECONDS in config.REQUIRED_KEYWORDS["dark"]
+        )
         # Flat should include date and filter
-        assert config.KEYWORD_DATE in config.REQUIRED_KEYWORDS["flat"]
-        assert config.KEYWORD_FILTER in config.REQUIRED_KEYWORDS["flat"]
+        assert config.NORMALIZED_HEADER_DATE in config.REQUIRED_KEYWORDS["flat"]
+        assert config.NORMALIZED_HEADER_FILTER in config.REQUIRED_KEYWORDS["flat"]
 
     def test_master_match_keywords(self):
         """Test that MASTER_MATCH_KEYWORDS excludes date and filter."""
-        assert config.KEYWORD_DATE not in config.MASTER_MATCH_KEYWORDS
-        assert config.KEYWORD_FILTER not in config.MASTER_MATCH_KEYWORDS
-        assert config.KEYWORD_CAMERA in config.MASTER_MATCH_KEYWORDS
+        assert config.NORMALIZED_HEADER_DATE not in config.MASTER_MATCH_KEYWORDS
+        assert config.NORMALIZED_HEADER_FILTER not in config.MASTER_MATCH_KEYWORDS
+        assert config.NORMALIZED_HEADER_CAMERA in config.MASTER_MATCH_KEYWORDS
 
     def test_image_type_constants(self):
         """Test that PixInsight image type constants are defined."""

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -20,12 +20,12 @@ class TestCreateGroupKey:
     def test_bias_group_key(self):
         """Test creating group key for bias frames."""
         headers = {
-            config.KEYWORD_TYPE: "bias",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
         key = create_group_key(headers, "bias")
         assert isinstance(key, tuple)
@@ -37,13 +37,13 @@ class TestCreateGroupKey:
     def test_dark_group_key(self):
         """Test creating group key for dark frames."""
         headers = {
-            config.KEYWORD_TYPE: "dark",
-            config.KEYWORD_EXPOSURESECONDS: "60.0",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_TYPE: "dark",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
         key = create_group_key(headers, "dark")
         assert isinstance(key, tuple)
@@ -54,14 +54,14 @@ class TestCreateGroupKey:
     def test_flat_group_key(self):
         """Test creating group key for flat frames."""
         headers = {
-            config.KEYWORD_TYPE: "flat",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_DATE: "2026-01-15",
-            config.KEYWORD_FILTER: "B",
+            config.NORMALIZED_HEADER_TYPE: "flat",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
         }
         key = create_group_key(headers, "flat")
         assert isinstance(key, tuple)
@@ -72,8 +72,8 @@ class TestCreateGroupKey:
     def test_missing_values_become_empty_string(self):
         """Test that missing header values become empty strings."""
         headers = {
-            config.KEYWORD_TYPE: "bias",
-            config.KEYWORD_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
             # Missing other required keywords
         }
         key = create_group_key(headers, "bias")
@@ -94,34 +94,34 @@ class TestGroupFiles:
             {
                 "path": "file1.fits",
                 "headers": {
-                    config.KEYWORD_TYPE: "bias",
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_TYPE: "bias",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                 },
             },
             {
                 "path": "file2.fits",
                 "headers": {
-                    config.KEYWORD_TYPE: "bias",
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_TYPE: "bias",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                 },
             },
             {
                 "path": "file3.fits",
                 "headers": {
-                    config.KEYWORD_TYPE: "bias",
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-9.00",  # Different temp
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_TYPE: "bias",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-9.00",  # Different temp
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                 },
             },
         ]
@@ -143,29 +143,29 @@ class TestGetGroupMetadata:
     def test_extract_metadata_for_bias(self):
         """Test extracting metadata for bias frames."""
         headers = {
-            config.KEYWORD_TYPE: "bias",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
         metadata = get_group_metadata(headers, "bias")
-        assert metadata[config.KEYWORD_TYPE] == "bias"
-        assert metadata[config.KEYWORD_CAMERA] == "ATR585M"
-        assert metadata[config.KEYWORD_SETTEMP] == "-10.00"
+        assert metadata[config.NORMALIZED_HEADER_TYPE] == "bias"
+        assert metadata[config.NORMALIZED_HEADER_CAMERA] == "ATR585M"
+        assert metadata[config.NORMALIZED_HEADER_SETTEMP] == "-10.00"
 
     def test_missing_values_not_included(self):
         """Test that missing header values are not included in metadata."""
         headers = {
-            config.KEYWORD_TYPE: "bias",
-            config.KEYWORD_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
             # Missing other keywords
         }
         metadata = get_group_metadata(headers, "bias")
-        assert config.KEYWORD_TYPE in metadata
-        assert config.KEYWORD_CAMERA in metadata
-        assert config.KEYWORD_SETTEMP not in metadata
+        assert config.NORMALIZED_HEADER_TYPE in metadata
+        assert config.NORMALIZED_HEADER_CAMERA in metadata
+        assert config.NORMALIZED_HEADER_SETTEMP not in metadata
 
     def test_unknown_frame_type_raises_error(self):
         """Test that unknown frame type raises ValueError."""

--- a/tests/test_master_matching.py
+++ b/tests/test_master_matching.py
@@ -23,22 +23,22 @@ class TestFindMatchingMasterForFlat:
         Path(master_dir).mkdir(parents=True, exist_ok=True)
         master_file = str(tmp_path / "masters" / "masterBias.xisf")
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         # ap-common returns dict with filename as key, metadata as value
         mock_get_metadata.return_value = {
             master_file: {
-                config.KEYWORD_TYPE: "MASTER BIAS",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_TYPE: "MASTER BIAS",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
             }
         }
 
@@ -54,23 +54,23 @@ class TestFindMatchingMasterForFlat:
         Path(master_dir).mkdir(parents=True, exist_ok=True)
         master_file = str(tmp_path / "masters" / "masterDark_60s.xisf")
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_EXPOSURESECONDS: "60.0",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
         }
 
         mock_get_metadata.return_value = {
             master_file: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
             }
         }
 
@@ -89,41 +89,41 @@ class TestFindMatchingMasterForFlat:
         master_70s = str(tmp_path / "masters" / "masterDark_70s.xisf")
 
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         # Flat exposure is 60s, should prefer 60s (exact match) over 50s or 70s
         mock_get_metadata.return_value = {
             master_50s: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "50.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "50.0",
             },
             master_60s: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
             },
             master_70s: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "70.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "70.0",
             },
         }
 
@@ -138,11 +138,11 @@ class TestFindMatchingMasterForFlat:
         """Test that function returns None when no matching master found."""
         master_dir = str(tmp_path / "masters")
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         mock_get_metadata.return_value = {}  # No matches
@@ -180,33 +180,33 @@ class TestFindMatchingMasterForFlat:
         master_180s = str(tmp_path / "masters" / "masterDark_180s.xisf")
 
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         # Flat exposure is 60s, but only have 120s and 180s darks
         # Should use 120s (closest higher exposure)
         mock_get_metadata.return_value = {
             master_120s: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "120.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "120.0",
             },
             master_180s: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "180.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "180.0",
             },
         }
 
@@ -227,23 +227,23 @@ class TestFindMatchingMasterForFlat:
 
         # Flat headers without exposure time
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
             # No KEYWORD_EXPOSURESECONDS
         }
 
         mock_get_metadata.return_value = {
             master_file: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
             }
         }
 
@@ -263,23 +263,23 @@ class TestFindMatchingMasterForFlat:
 
         # Flat headers with non-numeric exposure time
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_EXPOSURESECONDS: "not-a-number",  # Invalid
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "not-a-number",  # Invalid
         }
 
         mock_get_metadata.return_value = {
             master_file: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
             }
         }
 
@@ -299,31 +299,31 @@ class TestFindMatchingMasterForFlat:
         master_invalid = str(tmp_path / "masters" / "masterDark_invalid.xisf")
 
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         mock_get_metadata.return_value = {
             master_valid: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "60.0",  # Valid
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",  # Valid
             },
             master_invalid: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "corrupted",  # Invalid, should be skipped
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "corrupted",  # Invalid, should be skipped
             },
         }
 
@@ -344,32 +344,32 @@ class TestFindMatchingMasterForFlat:
         master2 = str(tmp_path / "masters" / "masterDark2.xisf")
 
         flat_headers = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
 
         # All masters have invalid exposure metadata
         mock_get_metadata.return_value = {
             master1: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "bad1",  # Invalid
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "bad1",  # Invalid
             },
             master2: {
-                config.KEYWORD_TYPE: "MASTER DARK",
-                config.KEYWORD_CAMERA: "ATR585M",
-                config.KEYWORD_SETTEMP: "-10.00",
-                config.KEYWORD_GAIN: "239",
-                config.KEYWORD_OFFSET: "150",
-                config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                config.KEYWORD_EXPOSURESECONDS: "bad2",  # Invalid
+                config.NORMALIZED_HEADER_TYPE: "MASTER DARK",
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                config.NORMALIZED_HEADER_EXPOSURESECONDS: "bad2",  # Invalid
             },
         }
 

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -50,11 +50,11 @@ class TestGenerateMasterFilename:
         }.get(k, k.upper())
 
         metadata = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
         filename = generate_master_filename(metadata, "bias")
         assert filename.startswith("masterBias")
@@ -74,12 +74,12 @@ class TestGenerateMasterFilename:
         }.get(k, k.upper())
 
         metadata = {
-            config.KEYWORD_EXPOSURESECONDS: "60.0",
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
         }
         filename = generate_master_filename(metadata, "dark")
         assert filename.startswith("masterDark")
@@ -99,13 +99,13 @@ class TestGenerateMasterFilename:
         }.get(k, k.upper())
 
         metadata = {
-            config.KEYWORD_CAMERA: "ATR585M",
-            config.KEYWORD_SETTEMP: "-10.00",
-            config.KEYWORD_GAIN: "239",
-            config.KEYWORD_OFFSET: "150",
-            config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-            config.KEYWORD_DATE: "2026-01-15",
-            config.KEYWORD_FILTER: "B",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
         }
         filename = generate_master_filename(metadata, "flat")
         assert filename.startswith("masterFlat")
@@ -117,7 +117,7 @@ class TestGenerateMasterFilename:
         """Test that invalid filename characters are sanitized."""
         mock_denormalize.return_value = "TEST:KEY/with\\chars"
 
-        metadata = {config.KEYWORD_CAMERA: "test:value/with\\chars"}
+        metadata = {config.NORMALIZED_HEADER_CAMERA: "test:value/with\\chars"}
         filename = generate_master_filename(metadata, "bias")
         assert ":" not in filename
         assert "/" not in filename
@@ -139,11 +139,11 @@ class TestGenerateCombinedScript:
         bias_groups = [
             (
                 {
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                 },
                 ["file1.fits", "file2.fits"],
             )
@@ -162,12 +162,12 @@ class TestGenerateCombinedScript:
         dark_groups = [
             (
                 {
-                    config.KEYWORD_EXPOSURESECONDS: "60.0",
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_EXPOSURESECONDS: "60.0",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
                 },
                 ["dark1.fits", "dark2.fits"],
             )
@@ -183,13 +183,13 @@ class TestGenerateCombinedScript:
         flat_groups = [
             (
                 {
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                    config.KEYWORD_DATE: "2026-01-15",
-                    config.KEYWORD_FILTER: "B",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                    config.NORMALIZED_HEADER_FILTER: "B",
                 },
                 ["flat1.fits", "flat2.fits"],
                 "bias_master.xisf",
@@ -210,13 +210,13 @@ class TestGenerateCombinedScript:
         flat_groups = [
             (
                 {
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                    config.KEYWORD_DATE: "2026-01-15",
-                    config.KEYWORD_FILTER: "B",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                    config.NORMALIZED_HEADER_FILTER: "B",
                 },
                 ["flat1.fits", "flat2.fits"],
                 None,  # No bias master
@@ -236,13 +236,13 @@ class TestGenerateCombinedScript:
         flat_groups = [
             (
                 {
-                    config.KEYWORD_CAMERA: "ATR585M",
-                    config.KEYWORD_SETTEMP: "-10.00",
-                    config.KEYWORD_GAIN: "239",
-                    config.KEYWORD_OFFSET: "150",
-                    config.KEYWORD_READOUTMODE: "Low Conversion Gain",
-                    config.KEYWORD_DATE: "2026-01-15",
-                    config.KEYWORD_FILTER: "B",
+                    config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                    config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                    config.NORMALIZED_HEADER_GAIN: "239",
+                    config.NORMALIZED_HEADER_OFFSET: "150",
+                    config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+                    config.NORMALIZED_HEADER_DATE: "2026-01-15",
+                    config.NORMALIZED_HEADER_FILTER: "B",
                 },
                 ["D:/input/flat1.fits", "D:/input/flat2.fits", "D:/input/flat3.fits"],
                 "bias_master.xisf",


### PR DESCRIPTION
- Remove KEYWORD_* aliases in config.py
- Use NORMALIZED_HEADER_* constants directly from ap-common
- Update all references across source and test files

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)