### PR TITLE
Fix typecheck error and enforce type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-verbose: install-dev
 	$(PYTHON) -m pytest -v
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_create_master || true
+	$(PYTHON) -m mypy ap_create_master
 
 coverage: install-dev
 	$(PYTHON) -m pytest --cov=ap_create_master --cov-report=term

--- a/ap_create_master/calibrate_masters.py
+++ b/ap_create_master/calibrate_masters.py
@@ -359,7 +359,6 @@ def main() -> int:
             args.dark_master_dir,
             args.script_dir,
             timestamp,
-            args.quiet,
         )
 
         if scripts:


### PR DESCRIPTION
- Remove extra args.quiet parameter from generate_masters call
- Remove || true from typecheck Makefile target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)