### PR TITLE
Fix documentation reference link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This tool is part of the astrophotography pipeline. For comprehensive documentat
 
 - **[Pipeline Overview](https://github.com/jewzaam/ap-base/blob/main/docs/index.md)** - Full pipeline documentation
 - **[Workflow Guide](https://github.com/jewzaam/ap-base/blob/main/docs/workflow.md)** - Detailed workflow with diagrams
-- **[ap-common Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-common.md)** - API reference for this tool
+- **[ap-create-master Reference](https://github.com/jewzaam/ap-base/blob/main/docs/tools/ap-create-master.md)** - API reference for this tool
 
 ## Installation
 


### PR DESCRIPTION
## Summary
Updated the README.md documentation reference link to point to the correct tool documentation page.

## Changes
- Changed the ap-common reference link to ap-create-master reference link
- Updated both the link text and URL to correctly reference `ap-create-master.md` instead of `ap-common.md`

## Details
The README was incorrectly linking to the ap-common tool documentation when it should have been linking to the ap-create-master tool documentation. This fix ensures users are directed to the correct API reference for this tool.

https://claude.ai/code/session_01X5cVt1gUZC51fkYe7ky1zM