### PR TITLE
Fix --quiet flag not being used (bug fix)

### DIFF
--- a/ap_create_master/calibrate_masters.py
+++ b/ap_create_master/calibrate_masters.py
@@ -444,7 +444,7 @@ def main() -> int:
     args = parser.parse_args()
 
     # Setup logging
-    logger = setup_logging(name="ap_create_master", debug=args.debug)
+    logger = setup_logging(name="ap_create_master", debug=args.debug, quiet=args.quiet)
 
     try:
         # Generate timestamp once to use for both script and log


### PR DESCRIPTION
Pass quiet argument to setup_logging() to enable WARNING-level logging when --quiet flag is used. The flag was defined but never connected to the logging system, making it non-functional.

Changes:
- Pass quiet=args.quiet to setup_logging() call

All 76 tests pass.

Addresses ap-base plan: Quiet Mode Support (Phase 2)

Assisted-by: Claude Code (Claude Sonnet 4.5)