### PR TITLE
Add progress indicators and clean CLI output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON := python
 
-.PHONY: install install-dev uninstall clean format lint typecheck test test-verbose coverage default
+.PHONY: install install-dev install-no-deps uninstall clean format lint typecheck test test-verbose coverage default
 
 default: format lint typecheck test coverage
 
@@ -10,6 +10,9 @@ install:
 
 install-dev:
 	$(PYTHON) -m pip install -e ".[dev]"
+
+install-no-deps:
+	$(PYTHON) -m pip install -e . --no-deps
 
 uninstall:
 	$(PYTHON) -m pip uninstall -y ap-create-master

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ python -m ap_create_master /path/to/flats /path/to/output \
 python -m ap_create_master /path/to/calibration /path/to/output --script-only
 ```
 
+**Dry run to see what would be generated:**
+```bash
+python -m ap_create_master /path/to/calibration /path/to/output --dryrun
+```
+
+**With debug output:**
+```bash
+python -m ap_create_master /path/to/calibration /path/to/output --debug \
+    --pixinsight-binary "C:\Program Files\PixInsight\bin\PixInsight.exe"
+```
+
+**Quiet mode (minimal output):**
+```bash
+python -m ap_create_master /path/to/calibration /path/to/output --quiet \
+    --pixinsight-binary "C:\Program Files\PixInsight\bin\PixInsight.exe"
+```
+
 ## Important Limitation
 
 Masters created in a run are **not used** for flat calibration in that same run. To calibrate flats, you must use existing masters from a library or run in stages:
@@ -114,6 +131,7 @@ Frames must have proper FITS keywords:
 python -m ap_create_master [-h] [--bias-master-dir DIR] [--dark-master-dir DIR]
                                 [--script-dir DIR] [--pixinsight-binary PATH]
                                 [--instance-id ID] [--no-force-exit] [--script-only]
+                                [--dryrun] [--debug] [--quiet]
                                 input_dir output_dir
 
 positional arguments:
@@ -129,6 +147,9 @@ optional arguments:
   --instance-id         PixInsight instance ID (default: 123)
   --no-force-exit       Keep PixInsight open after execution completes
   --script-only         Generate scripts only, do not execute PixInsight
+  --dryrun              Show what would be done without executing
+  --debug               Enable debug logging
+  --quiet, -q           Suppress progress output
 ```
 
 Run `python -m ap_create_master --help` for full details.

--- a/ap_create_master/templates/combined.j2
+++ b/ap_create_master/templates/combined.j2
@@ -12,28 +12,49 @@ console.show();
 console.writeln("Starting calibration master generation...");
 console.flush();
 
+{% if flat_groups %}
+// ===== PHASE 1: Calibrating Flat Frames =====
+{% set calibration_needed = namespace(found=false) %}
+{% for group in flat_groups %}
+{% if group.master_bias_enabled or group.master_dark_enabled %}
+{% set calibration_needed.found = true %}
+{% endif %}
+{% endfor %}
+{% if calibration_needed.found %}
+console.writeln("\n===== Phase 1: Calibrating Flat Frames =====");
+console.flush();
+{% for group in flat_groups %}
+{% if group.master_bias_enabled or group.master_dark_enabled %}
+{% include 'ImageCalibration_flat.j2' %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+// ===== PHASE 2: Creating Master Frames =====
+console.writeln("\n===== Phase 2: Creating Master Frames =====");
+console.flush();
+
 {% if bias_groups %}
-// ===== Processing Bias Frames =====
+console.writeln("Processing Bias Frames...");
+console.flush();
 {% for group in bias_groups %}
 {% include 'ImageIntegration_bias.j2' %}
 {% endfor %}
 {% endif %}
 
 {% if dark_groups %}
-// ===== Processing Dark Frames =====
+console.writeln("Processing Dark Frames...");
+console.flush();
 {% for group in dark_groups %}
 {% include 'ImageIntegration_dark.j2' %}
 {% endfor %}
 {% endif %}
 
 {% if flat_groups %}
-// ===== Processing Flat Frames =====
+console.writeln("Processing Flat Frames...");
+console.flush();
 {% for group in flat_groups %}
-{% if group.master_bias_enabled or group.master_dark_enabled %}
-// ===== Flats: Calibration Phase =====
-{% include 'ImageCalibration_flat.j2' %}
-{% endif %}
-// ===== Flats: Integration Phase =====
 {% include 'ImageIntegration_flat.j2' %}
 {% endfor %}
 {% endif %}

--- a/tests/test_calibrate_masters.py
+++ b/tests/test_calibrate_masters.py
@@ -265,7 +265,7 @@ class TestGenerateMasters:
 
     @patch("ap_common.get_filtered_metadata")
     def test_handles_ap_common_exception_gracefully(
-        self, mock_get_filtered, tmp_path, capsys
+        self, mock_get_filtered, tmp_path, caplog
     ):
         """Test that exceptions from ap-common are handled gracefully."""
         input_dir = str(tmp_path / "input")
@@ -287,10 +287,12 @@ class TestGenerateMasters:
 
         # Should still complete successfully, just with no dark files
         assert scripts == []
-        # Should print warning about failed discovery
-        captured = capsys.readouterr()
-        assert "Warning" in captured.out
-        assert "dark" in captured.out.lower()
+        # Should log warning about failed discovery
+        assert any(
+            "Failed to discover dark files" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
 
     @patch("ap_common.get_filtered_metadata")
     @patch("ap_create_master.calibrate_masters.group_files")

--- a/tests/test_calibrate_masters_integration.py
+++ b/tests/test_calibrate_masters_integration.py
@@ -822,7 +822,12 @@ class TestPixInsightExecution:
         mock_subprocess.return_value = mock_result
 
         exit_code = run_pixinsight(
-            str(pixinsight_binary), str(script_path), instance_id=123, force_exit=True
+            str(pixinsight_binary),
+            str(script_path),
+            calibrated_files=[],
+            master_files=[],
+            instance_id=123,
+            force_exit=True,
         )
 
         assert exit_code == 0
@@ -852,7 +857,12 @@ class TestPixInsightExecution:
         mock_result.stdout = "Error: Something went wrong"
         mock_subprocess.return_value = mock_result
 
-        exit_code = run_pixinsight(str(pixinsight_binary), str(script_path))
+        exit_code = run_pixinsight(
+            str(pixinsight_binary),
+            str(script_path),
+            calibrated_files=[],
+            master_files=[],
+        )
 
         assert exit_code == 1
 
@@ -875,7 +885,11 @@ class TestPixInsightExecution:
         mock_subprocess.return_value = mock_result
 
         exit_code = run_pixinsight(
-            str(pixinsight_binary), str(script_path), force_exit=False
+            str(pixinsight_binary),
+            str(script_path),
+            calibrated_files=[],
+            master_files=[],
+            force_exit=False,
         )
 
         assert exit_code == 0
@@ -894,7 +908,12 @@ class TestPixInsightExecution:
         pixinsight_binary = tmp_path / "bin" / "PixInsight.exe"
 
         with pytest.raises(FileNotFoundError, match="PixInsight binary not found"):
-            run_pixinsight(str(pixinsight_binary), str(script_path))
+            run_pixinsight(
+                str(pixinsight_binary),
+                str(script_path),
+                calibrated_files=[],
+                master_files=[],
+            )
 
     def test_run_pixinsight_script_not_found(self, tmp_path):
         """Test error when script file doesn't exist."""
@@ -907,7 +926,12 @@ class TestPixInsightExecution:
         pixinsight_binary.write_text("fake binary")
 
         with pytest.raises(FileNotFoundError, match="Script not found"):
-            run_pixinsight(str(pixinsight_binary), str(script_path))
+            run_pixinsight(
+                str(pixinsight_binary),
+                str(script_path),
+                calibrated_files=[],
+                master_files=[],
+            )
 
     @patch("subprocess.run")
     def test_run_pixinsight_subprocess_exception(self, mock_subprocess, tmp_path):
@@ -925,4 +949,9 @@ class TestPixInsightExecution:
         mock_subprocess.side_effect = OSError("Permission denied")
 
         with pytest.raises(OSError, match="Permission denied"):
-            run_pixinsight(str(pixinsight_binary), str(script_path))
+            run_pixinsight(
+                str(pixinsight_binary),
+                str(script_path),
+                calibrated_files=[],
+                master_files=[],
+            )


### PR DESCRIPTION
- Add two-phase progress monitoring during PixInsight execution (calibration → master creation)
- Separate flat calibration from master creation in PixInsight script template
- Move verbose output to debug mode, clean output by default
- Add --dryrun flag to preview without generating scripts
- Add --debug flag for detailed logging and PixInsight stderr
- Add --quiet flag to suppress progress bars
- Update README with usage examples for new flags
- Add install-no-deps Makefile target
- Update all tests for new function signatures

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)