### PR TITLE
Set default progress bar description width for alignment

### DIFF
--- a/ap_create_master/calibrate_masters.py
+++ b/ap_create_master/calibrate_masters.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 
 POLLING_FREQUENCY_SECONDS = 1
 
+# Set default description width for aligned progress bars
+# Aligns: "Loading metadata", "Enriching metadata", "Calibrating flats", "Creating masters"
+ProgressTracker.set_default_desc_width(20)
+
 
 def get_expected_output_files(
     master_dir: Path,


### PR DESCRIPTION
- Set ProgressTracker default description width to 20 characters to align progress bars for "Loading metadata", "Enriching metadata", "Calibrating flats", and "Creating masters"

Assisted-by: Claude Code (Claude Sonnet 4.5)