### PR TITLE
Replace hardcoded strings with constants from ap_common

### DIFF
--- a/ap_create_master/calibrate_masters.py
+++ b/ap_create_master/calibrate_masters.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import ap_common
+from ap_common.constants import (
+    DEFAULT_FITS_PATTERN,
+    HEADER_IMAGETYP,
+    TYPE_MASTER_BIAS,
+    TYPE_MASTER_DARK,
+    TYPE_MASTER_FLAT,
+)
 from ap_common.fits import update_xisf_headers
 from ap_common.logging_config import setup_logging
 from ap_common.progress import ProgressTracker
@@ -183,9 +190,9 @@ def write_master_imagetyp_headers(master_files: List[Tuple[str, str]]) -> None:
                      frame_type is "bias", "dark", or "flat"
     """
     type_mapping = {
-        "bias": "MASTER BIAS",
-        "dark": "MASTER DARK",
-        "flat": "MASTER FLAT",
+        "bias": TYPE_MASTER_BIAS,
+        "dark": TYPE_MASTER_DARK,
+        "flat": TYPE_MASTER_FLAT,
     }
 
     for master_file, frame_type in master_files:
@@ -205,7 +212,7 @@ def write_master_imagetyp_headers(master_files: List[Tuple[str, str]]) -> None:
             # Get denormalized header name (should be "IMAGETYP")
             header_key = ap_common.denormalize_header(config.NORMALIZED_HEADER_TYPE)
             if not header_key:
-                header_key = "IMAGETYP"  # Fallback
+                header_key = HEADER_IMAGETYP  # Fallback
 
             # Update IMAGETYP header using ap-common
             update_xisf_headers(
@@ -276,7 +283,7 @@ def generate_masters(
                 dirs=[input_dir],
                 filters={config.NORMALIZED_HEADER_TYPE: frame_type.upper()},
                 profileFromPath=False,
-                patterns=[r".*\.fits$", r".*\.fit$"],
+                patterns=[DEFAULT_FITS_PATTERN],
                 recursive=True,
                 required_properties=config.REQUIRED_KEYWORDS[frame_type],
                 debug=debug,
@@ -689,7 +696,7 @@ def main() -> int:
                             dirs=[args.input_dir],
                             filters={config.NORMALIZED_HEADER_TYPE: frame_type.upper()},
                             profileFromPath=False,
-                            patterns=[r".*\.fits$", r".*\.fit$"],
+                            patterns=[DEFAULT_FITS_PATTERN],
                             recursive=True,
                             required_properties=config.REQUIRED_KEYWORDS[frame_type],
                             debug=False,

--- a/ap_create_master/config.py
+++ b/ap_create_master/config.py
@@ -21,6 +21,7 @@ from ap_common.constants import (
     TYPE_BIAS,
     TYPE_DARK,
     TYPE_FLAT,
+    TYPE_LIGHT,
 )
 
 # Frame type list for processing
@@ -71,7 +72,7 @@ MASTER_MATCH_KEYWORDS = [
 ]
 
 # Frame types to ignore (e.g., lights)
-IGNORED_TYPES = ["light"]
+IGNORED_TYPES = [TYPE_LIGHT.lower()]
 
 # PixInsight ImageIntegration imageType constants
 IMAGE_TYPE_BIAS = 1

--- a/ap_create_master/master_matching.py
+++ b/ap_create_master/master_matching.py
@@ -6,6 +6,12 @@ Find matching bias/dark masters for flat calibration.
 
 import logging
 import ap_common
+from ap_common.constants import (
+    DEFAULT_CALIBRATION_PATTERNS,
+    TYPE_MASTER_BIAS,
+    TYPE_MASTER_DARK,
+    TYPE_MASTER_FLAT,
+)
 from ap_common.metadata import build_normalized_filters
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
@@ -54,9 +60,14 @@ def find_matching_master_for_flat(
         return None
 
     # Build filters dict: TYPE and all instrument settings
-    # TYPE format: "MASTER BIAS", "MASTER DARK", "MASTER FLAT"
+    # TYPE format: "MASTER BIAS", "MASTER DARK"
     # These are written by ap-create-master after PixInsight generates masters
-    type_value = f"MASTER {master_type.upper()}"
+    master_type_constants = {
+        "bias": TYPE_MASTER_BIAS,
+        "dark": TYPE_MASTER_DARK,
+        "flat": TYPE_MASTER_FLAT,
+    }
+    type_value = master_type_constants[master_type]
     filters = build_normalized_filters(
         flat_headers,
         config.MASTER_MATCH_KEYWORDS,
@@ -79,7 +90,7 @@ def find_matching_master_for_flat(
             dirs=[str(master_path)],
             filters=filters,
             profileFromPath=False,
-            patterns=[r".*\.xisf$", r".*\.fits$"],
+            patterns=DEFAULT_CALIBRATION_PATTERNS,
             recursive=True,
             required_properties=required_properties,
             debug=False,


### PR DESCRIPTION
## Summary
This PR refactors the codebase to use constants from `ap_common` instead of hardcoded string literals, improving maintainability and reducing duplication across the project.

## Key Changes
- **Import constants from ap_common**: Added imports for `DEFAULT_FITS_PATTERN`, `DEFAULT_CALIBRATION_PATTERNS`, `HEADER_IMAGETYP`, `TYPE_MASTER_BIAS`, `TYPE_MASTER_DARK`, `TYPE_MASTER_FLAT`, and `TYPE_LIGHT` from `ap_common.constants`
- **calibrate_masters.py**:
  - Replaced hardcoded master type strings ("MASTER BIAS", "MASTER DARK", "MASTER FLAT") with their corresponding constants in the `type_mapping` dictionary
  - Replaced hardcoded "IMAGETYP" fallback with `HEADER_IMAGETYP` constant
  - Replaced inline FITS file patterns `[r".*\.fits$", r".*\.fit$"]` with `DEFAULT_FITS_PATTERN` constant in two locations
- **master_matching.py**:
  - Replaced hardcoded master type string construction with a dictionary mapping to constants
  - Replaced inline calibration file patterns `[r".*\.xisf$", r".*\.fits$"]` with `DEFAULT_CALIBRATION_PATTERNS` constant
- **config.py**:
  - Imported `TYPE_LIGHT` constant from `ap_common.constants`
  - Replaced hardcoded "light" string in `IGNORED_TYPES` with `TYPE_LIGHT.lower()` for consistency

## Implementation Details
- All string constants are now sourced from a single location (`ap_common.constants`), ensuring consistency across the project
- File pattern matching is now centralized, making it easier to update patterns in the future
- The changes maintain backward compatibility while improving code maintainability

https://claude.ai/code/session_013KbcN5S29mMe2KjcaU6kxB