### PR TITLE
Add minimum image count validation for master calibration

### DIFF
--- a/ap_create_master/calibrate_masters.py
+++ b/ap_create_master/calibrate_masters.py
@@ -319,10 +319,19 @@ def generate_masters(
         for group_key, group_files_list in bias_groups.items():
             metadata = get_group_metadata(group_files_list[0]["headers"], "bias")
             file_paths = [f["path"] for f in group_files_list]
+            master_name = generate_master_filename(metadata, "bias")
+
+            if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                logger.warning(
+                    f"Skipping bias group {master_name}: "
+                    f"has {len(file_paths)} image(s), "
+                    f"need at least {config.MIN_IMAGES_FOR_INTEGRATION}"
+                )
+                continue
+
             bias_groups_list.append((metadata, file_paths))
 
             # Track master file for header updates
-            master_name = generate_master_filename(metadata, "bias")
             master_file_path = str(master_dir / f"{master_name}.xisf")
             master_files_list.append((master_file_path, "bias"))
 
@@ -337,10 +346,19 @@ def generate_masters(
         for group_key, group_files_list in dark_groups.items():
             metadata = get_group_metadata(group_files_list[0]["headers"], "dark")
             file_paths = [f["path"] for f in group_files_list]
+            master_name = generate_master_filename(metadata, "dark")
+
+            if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                logger.warning(
+                    f"Skipping dark group {master_name}: "
+                    f"has {len(file_paths)} image(s), "
+                    f"need at least {config.MIN_IMAGES_FOR_INTEGRATION}"
+                )
+                continue
+
             dark_groups_list.append((metadata, file_paths))
 
             # Track master file for header updates
-            master_name = generate_master_filename(metadata, "dark")
             master_file_path = str(master_dir / f"{master_name}.xisf")
             master_files_list.append((master_file_path, "dark"))
 
@@ -357,6 +375,15 @@ def generate_masters(
             first_file = group_files_list[0]
             metadata = get_group_metadata(first_file["headers"], "flat")
             file_paths = [f["path"] for f in group_files_list]
+            master_name = generate_master_filename(metadata, "flat")
+
+            if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                logger.warning(
+                    f"Skipping flat group {master_name}: "
+                    f"has {len(file_paths)} image(s), "
+                    f"need at least {config.MIN_IMAGES_FOR_INTEGRATION}"
+                )
+                continue
 
             # Find matching masters
             master_bias_xisf = None
@@ -391,7 +418,6 @@ def generate_masters(
             )
 
             # Track master file for header updates
-            master_name = generate_master_filename(metadata, "flat")
             master_file_path = str(master_dir / f"{master_name}.xisf")
             master_files_list.append((master_file_path, "flat"))
 
@@ -724,6 +750,8 @@ def main() -> int:
                             group_files_list[0]["headers"], "bias"
                         )
                         file_paths = [f["path"] for f in group_files_list]
+                        if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                            continue
                         bias_groups_list.append((metadata, file_paths))
 
                 if files_by_type["dark"]:
@@ -733,6 +761,8 @@ def main() -> int:
                             group_files_list[0]["headers"], "dark"
                         )
                         file_paths = [f["path"] for f in group_files_list]
+                        if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                            continue
                         dark_groups_list.append((metadata, file_paths))
 
                 if files_by_type["flat"]:
@@ -741,6 +771,8 @@ def main() -> int:
                         first_file = group_files_list[0]
                         metadata = get_group_metadata(first_file["headers"], "flat")
                         file_paths = [f["path"] for f in group_files_list]
+                        if len(file_paths) < config.MIN_IMAGES_FOR_INTEGRATION:
+                            continue
 
                         master_bias_xisf = None
                         master_dark_xisf = None

--- a/ap_create_master/config.py
+++ b/ap_create_master/config.py
@@ -74,6 +74,9 @@ MASTER_MATCH_KEYWORDS = [
 # Frame types to ignore (e.g., lights)
 IGNORED_TYPES = [TYPE_LIGHT.lower()]
 
+# PixInsight ImageIntegration requires at least 3 source images
+MIN_IMAGES_FOR_INTEGRATION = 3
+
 # PixInsight ImageIntegration imageType constants
 IMAGE_TYPE_BIAS = 1
 IMAGE_TYPE_DARK = 2

--- a/tests/test_calibrate_masters.py
+++ b/tests/test_calibrate_masters.py
@@ -41,37 +41,28 @@ class TestGenerateMasters:
         output_dir = str(tmp_path / "output")
         os.makedirs(input_dir, exist_ok=True)
 
+        bias_headers = {
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+
         # Mock file discovery
         mock_get_filtered.return_value = {
-            "bias1.fits": {
-                config.NORMALIZED_HEADER_TYPE: "bias",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-            },
-            "bias2.fits": {
-                config.NORMALIZED_HEADER_TYPE: "bias",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-            },
+            "bias1.fits": bias_headers,
+            "bias2.fits": bias_headers,
+            "bias3.fits": bias_headers,
         }
 
         # Mock grouping
         mock_group_files.return_value = {
             ("bias", "ATR585M", "-10.00", "239", "150", "Low Conversion Gain"): [
-                {
-                    "path": "bias1.fits",
-                    "headers": mock_get_filtered.return_value["bias1.fits"],
-                },
-                {
-                    "path": "bias2.fits",
-                    "headers": mock_get_filtered.return_value["bias2.fits"],
-                },
+                {"path": "bias1.fits", "headers": bias_headers},
+                {"path": "bias2.fits", "headers": bias_headers},
+                {"path": "bias3.fits", "headers": bias_headers},
             ]
         }
 
@@ -141,19 +132,23 @@ class TestGenerateMasters:
         dark_master_dir = str(tmp_path / "dark_masters")
         os.makedirs(input_dir, exist_ok=True)
 
+        flat_headers = {
+            config.NORMALIZED_HEADER_TYPE: "flat",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
+        }
+
         # Mock flat file discovery
         mock_get_filtered.return_value = {
-            "flat1.fits": {
-                config.NORMALIZED_HEADER_TYPE: "flat",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-                config.NORMALIZED_HEADER_DATE: "2026-01-15",
-                config.NORMALIZED_HEADER_FILTER: "B",
-                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",
-            }
+            "flat1.fits": flat_headers,
+            "flat2.fits": flat_headers,
+            "flat3.fits": flat_headers,
         }
 
         # Mock grouping
@@ -168,10 +163,9 @@ class TestGenerateMasters:
                 "2026-01-15",
                 "B",
             ): [
-                {
-                    "path": "flat1.fits",
-                    "headers": mock_get_filtered.return_value["flat1.fits"],
-                }
+                {"path": "flat1.fits", "headers": flat_headers},
+                {"path": "flat2.fits", "headers": flat_headers},
+                {"path": "flat3.fits", "headers": flat_headers},
             ]
         }
 
@@ -221,23 +215,26 @@ class TestGenerateMasters:
         custom_script_dir = str(tmp_path / "custom_scripts")
         os.makedirs(input_dir, exist_ok=True)
 
+        bias_headers = {
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+
         mock_get_filtered.return_value = {
-            "bias1.fits": {
-                config.NORMALIZED_HEADER_TYPE: "bias",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-            }
+            "bias1.fits": bias_headers,
+            "bias2.fits": bias_headers,
+            "bias3.fits": bias_headers,
         }
 
         mock_group_files.return_value = {
             ("bias", "ATR585M", "-10.00", "239", "150", "Low Conversion Gain"): [
-                {
-                    "path": "bias1.fits",
-                    "headers": mock_get_filtered.return_value["bias1.fits"],
-                }
+                {"path": "bias1.fits", "headers": bias_headers},
+                {"path": "bias2.fits", "headers": bias_headers},
+                {"path": "bias3.fits", "headers": bias_headers},
             ]
         }
 
@@ -313,30 +310,34 @@ class TestGenerateMasters:
         dark_master_dir = str(tmp_path / "dark_masters")
         os.makedirs(input_dir, exist_ok=True)
 
+        flat_headers_invalid = {
+            config.NORMALIZED_HEADER_TYPE: "flat",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "invalid",  # Non-numeric
+        }
+        flat_headers_valid = {
+            config.NORMALIZED_HEADER_TYPE: "flat",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            config.NORMALIZED_HEADER_DATE: "2026-01-15",
+            config.NORMALIZED_HEADER_FILTER: "B",
+            config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",  # Valid
+        }
+
         # Flat with invalid exposure time (non-numeric string)
         mock_get_filtered.return_value = {
-            "flat1.fits": {
-                config.NORMALIZED_HEADER_TYPE: "flat",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-                config.NORMALIZED_HEADER_DATE: "2026-01-15",
-                config.NORMALIZED_HEADER_FILTER: "B",
-                config.NORMALIZED_HEADER_EXPOSURESECONDS: "invalid",  # Non-numeric
-            },
-            "flat2.fits": {
-                config.NORMALIZED_HEADER_TYPE: "flat",
-                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
-                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
-                config.NORMALIZED_HEADER_GAIN: "239",
-                config.NORMALIZED_HEADER_OFFSET: "150",
-                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
-                config.NORMALIZED_HEADER_DATE: "2026-01-15",
-                config.NORMALIZED_HEADER_FILTER: "B",
-                config.NORMALIZED_HEADER_EXPOSURESECONDS: "1.5",  # Valid
-            },
+            "flat1.fits": flat_headers_invalid,
+            "flat2.fits": flat_headers_valid,
+            "flat3.fits": flat_headers_valid,
         }
 
         mock_group_files.return_value = {
@@ -350,14 +351,9 @@ class TestGenerateMasters:
                 "2026-01-15",
                 "B",
             ): [
-                {
-                    "path": "flat1.fits",
-                    "headers": mock_get_filtered.return_value["flat1.fits"],
-                },
-                {
-                    "path": "flat2.fits",
-                    "headers": mock_get_filtered.return_value["flat2.fits"],
-                },
+                {"path": "flat1.fits", "headers": flat_headers_invalid},
+                {"path": "flat2.fits", "headers": flat_headers_valid},
+                {"path": "flat3.fits", "headers": flat_headers_valid},
             ]
         }
 
@@ -381,12 +377,172 @@ class TestGenerateMasters:
         # Should still generate script successfully
         assert len(scripts) == 1
         # Should have called find_matching_master_for_flat
-        # with valid exposure time (1.5)
+        # with valid exposure times (1.5)
         # Invalid exposure should be skipped
         assert mock_find_master.call_count == 1
         call_args = mock_find_master.call_args
         # flat_exposure_times is the 4th positional argument (index 0, 1, 2, 3)
-        assert call_args[0][3] == [1.5]  # Only valid exposure included
+        assert call_args[0][3] == [1.5, 1.5]  # Only valid exposures included
+
+    @patch("ap_common.get_filtered_metadata")
+    @patch("ap_create_master.calibrate_masters.group_files")
+    @patch("ap_create_master.calibrate_masters.get_group_metadata")
+    @patch("ap_create_master.calibrate_masters.generate_combined_script")
+    def test_warns_and_skips_group_with_insufficient_images(
+        self,
+        mock_generate_script,
+        mock_get_metadata,
+        mock_group_files,
+        mock_get_filtered,
+        tmp_path,
+        caplog,
+    ):
+        """Test that groups with fewer than 3 images are skipped with a warning."""
+        input_dir = str(tmp_path / "input")
+        output_dir = str(tmp_path / "output")
+        os.makedirs(input_dir, exist_ok=True)
+
+        bias_headers = {
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+
+        # Only 1 bias file in group
+        mock_get_filtered.return_value = {"bias1.fits": bias_headers}
+
+        mock_group_files.return_value = {
+            ("bias", "ATR585M", "-10.00", "239", "150", "Low Conversion Gain"): [
+                {"path": "bias1.fits", "headers": bias_headers},
+            ]
+        }
+
+        mock_get_metadata.return_value = {
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+
+        mock_generate_script.return_value = "// Generated script"
+
+        scripts, _ = generate_masters(input_dir, output_dir)
+
+        # Group should be skipped, no script generated
+        assert scripts == []
+        mock_generate_script.assert_not_called()
+
+        # Should log a warning about insufficient images
+        assert any(
+            "Skipping bias group" in record.message
+            and "has 1 image(s)" in record.message
+            and "need at least 3" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
+    @patch("ap_common.get_filtered_metadata")
+    @patch("ap_create_master.calibrate_masters.group_files")
+    @patch("ap_create_master.calibrate_masters.get_group_metadata")
+    @patch("ap_create_master.calibrate_masters.generate_combined_script")
+    def test_skips_insufficient_group_but_keeps_valid_groups(
+        self,
+        mock_generate_script,
+        mock_get_metadata,
+        mock_group_files,
+        mock_get_filtered,
+        tmp_path,
+        caplog,
+    ):
+        """Test that only insufficient groups are skipped; valid groups proceed."""
+        input_dir = str(tmp_path / "input")
+        output_dir = str(tmp_path / "output")
+        os.makedirs(input_dir, exist_ok=True)
+
+        bias_headers_a = {
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+        bias_headers_b = {
+            config.NORMALIZED_HEADER_TYPE: "bias",
+            config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+            config.NORMALIZED_HEADER_SETTEMP: "-20.00",
+            config.NORMALIZED_HEADER_GAIN: "239",
+            config.NORMALIZED_HEADER_OFFSET: "150",
+            config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+        }
+
+        # Return bias files only for BIAS type, empty for others
+        def get_filtered_side_effect(*args, **kwargs):
+            frame_type = kwargs.get("filters", {}).get(
+                config.NORMALIZED_HEADER_TYPE, ""
+            )
+            if frame_type == "BIAS":
+                return {
+                    "bias_a1.fits": bias_headers_a,
+                    "bias_b1.fits": bias_headers_b,
+                    "bias_b2.fits": bias_headers_b,
+                    "bias_b3.fits": bias_headers_b,
+                }
+            return {}
+
+        mock_get_filtered.side_effect = get_filtered_side_effect
+
+        # Two groups: group A has 1 file (skip), group B has 3 files (keep)
+        mock_group_files.return_value = {
+            ("bias", "ATR585M", "-10.00", "239", "150", "Low Conversion Gain"): [
+                {"path": "bias_a1.fits", "headers": bias_headers_a},
+            ],
+            ("bias", "ATR585M", "-20.00", "239", "150", "Low Conversion Gain"): [
+                {"path": "bias_b1.fits", "headers": bias_headers_b},
+                {"path": "bias_b2.fits", "headers": bias_headers_b},
+                {"path": "bias_b3.fits", "headers": bias_headers_b},
+            ],
+        }
+
+        mock_get_metadata.side_effect = [
+            {
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-10.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            },
+            {
+                config.NORMALIZED_HEADER_CAMERA: "ATR585M",
+                config.NORMALIZED_HEADER_SETTEMP: "-20.00",
+                config.NORMALIZED_HEADER_GAIN: "239",
+                config.NORMALIZED_HEADER_OFFSET: "150",
+                config.NORMALIZED_HEADER_READOUTMODE: "Low Conversion Gain",
+            },
+        ]
+
+        mock_generate_script.return_value = "// Generated script"
+
+        scripts, _ = generate_masters(input_dir, output_dir)
+
+        # Valid group should still generate a script
+        assert len(scripts) == 1
+        mock_generate_script.assert_called_once()
+
+        # Should have only 1 bias group (the one with 3 files)
+        call_args = mock_generate_script.call_args
+        assert len(call_args[0][1]) == 1  # Only 1 bias group passed
+
+        # Should log a warning for the skipped group
+        assert any(
+            "Skipping bias group" in record.message
+            and record.levelname == "WARNING"
+            for record in caplog.records
+        )
 
 
 class TestWriteMasterImagetypHeaders:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,10 @@ class TestConfig:
         assert config.NORMALIZED_HEADER_FILTER not in config.MASTER_MATCH_KEYWORDS
         assert config.NORMALIZED_HEADER_CAMERA in config.MASTER_MATCH_KEYWORDS
 
+    def test_min_images_for_integration(self):
+        """Test that MIN_IMAGES_FOR_INTEGRATION is defined and equals 3."""
+        assert config.MIN_IMAGES_FOR_INTEGRATION == 3
+
     def test_image_type_constants(self):
         """Test that PixInsight image type constants are defined."""
         assert config.IMAGE_TYPE_BIAS == 1


### PR DESCRIPTION
## Summary
This PR adds validation to ensure that image groups have a minimum number of frames before attempting to create master calibration files. PixInsight's ImageIntegration process requires at least 3 source images, so groups with fewer images are now skipped with a warning rather than failing during processing.

## Key Changes
- **Added `MIN_IMAGES_FOR_INTEGRATION` constant** to `config.py` set to 3, defining the minimum required images for PixInsight integration
- **Implemented validation checks** in `generate_masters()` for bias, dark, and flat frame groups that:
  - Check if a group has fewer than the minimum required images
  - Log a warning message indicating the group is being skipped and why
  - Skip processing that group and continue with valid groups
- **Updated test fixtures** across both unit and integration tests to provide 3 images per group (previously many tests used only 1 image), ensuring tests reflect realistic scenarios and pass with the new validation
- **Added new test cases** to verify:
  - Groups with insufficient images are properly skipped with appropriate warnings
  - Valid groups continue to be processed even when other groups are skipped

## Implementation Details
- The validation occurs early in the group processing loop, before attempting to generate master filenames or scripts
- Warning messages include the master name, actual image count, and minimum required count for clarity
- The change is backward compatible - existing valid groups with 3+ images are unaffected
- Test data was standardized to use 3 images per group consistently across all test scenarios

https://claude.ai/code/session_01Hk6zDvdBPXSyBugjfzbfB7